### PR TITLE
Adjust optimizers to support mixed precision

### DIFF
--- a/custom_scheduler/LoraEasyCustomOptimizer/compass.py
+++ b/custom_scheduler/LoraEasyCustomOptimizer/compass.py
@@ -76,7 +76,7 @@ class Compass(Optimizer):
                     ema = state["ema"].to(torch.float32)
                     ema_squared = state["ema_squared"].to(torch.float32)
                 else:
-                    grad = p.grad.data
+                    grad = grad.data
                     ema, ema_squared = state["ema"], state["ema_squared"]
 
                 beta1, beta2 = group["betas"]

--- a/custom_scheduler/LoraEasyCustomOptimizer/lpfadamw.py
+++ b/custom_scheduler/LoraEasyCustomOptimizer/lpfadamw.py
@@ -49,7 +49,6 @@ class LPFAdamW(Optimizer):
         loss = closure() if closure is not None else None
         for group in self.param_groups:
             for p in group["params"]:
-                assert p.dtype == torch.bfloat16, "only bfloat 16 is supported."
                 if p.grad is None:
                     continue
                 grad = p.grad
@@ -62,17 +61,21 @@ class LPFAdamW(Optimizer):
                 if len(state) == 0:
                     state["step"] = 0
                     # Exponential moving average of gradient values
-                    state["smoothing"] = torch.zeros_like(p.data, dtype=torch.bfloat16)
-                    state["ema"] = torch.zeros_like(p.data, dtype=torch.bfloat16)
+                    state["smoothing"] = torch.zeros_like(p.data)
+                    state["ema"] = torch.zeros_like(p.data)
                     # Exponential moving average of squared gradient values
-                    state["ema_squared"] = torch.zeros_like(p.data, dtype=torch.bfloat16)
+                    state["ema_squared"] = torch.zeros_like(p.data)
 
                 # unpack
-                grad = grad.to(torch.float32)
-                p_fp32 = p.clone().to(torch.float32)
-                smoothing = state["smoothing"].to(torch.float32)
-                ema = state["ema"].to(torch.float32)
-                ema_squared = state["ema_squared"].to(torch.float32)
+                if p.dtype in {torch.float16, torch.bfloat16}:
+                    grad = grad.to(torch.float32)
+                    p_fp32 = p.clone().to(torch.float32)
+                    smoothing = state["smoothing"].to(torch.float32)
+                    ema = state["ema"].to(torch.float32)
+                    ema_squared = state["ema_squared"].to(torch.float32)
+                else:
+                    grad = p.grad.data
+                    ema, ema_squared, smoothing = state["ema"], state["ema_squared"], state["smoothing"]
 
                 beta1, beta2, beta3 = group["betas"]
                 amplification_factor = group["amp_fac"]
@@ -107,10 +110,16 @@ class LPFAdamW(Optimizer):
 
                 if weight_decay != 0:
                     # Perform stepweight decay
-                    p_fp32.data.mul_(1 - step_size * weight_decay)
+                    if p.dtype in {torch.float16, torch.bfloat16}:
+                        p_fp32.data.mul_(1 - step_size * weight_decay)
+                    else:
+                        p.data.mul_(1 - step_size * weight_decay)
 
                 # p = p - lr * grad / denom
-                p_fp32.data.addcdiv_(ema, denom, value=-step_size)
+                if p.dtype in {torch.float16, torch.bfloat16}:
+                    p_fp32.data.addcdiv_(grad, denom, value=-step_size)
+                else:
+                    p.data.addcdiv_(grad, denom, value=-step_size)
 
                 # pack
                 if p.dtype in {torch.float16, torch.bfloat16}:

--- a/custom_scheduler/LoraEasyCustomOptimizer/lpfadamw.py
+++ b/custom_scheduler/LoraEasyCustomOptimizer/lpfadamw.py
@@ -74,7 +74,7 @@ class LPFAdamW(Optimizer):
                     ema = state["ema"].to(torch.float32)
                     ema_squared = state["ema_squared"].to(torch.float32)
                 else:
-                    grad = p.grad.data
+                    grad = grad.data
                     ema, ema_squared, smoothing = state["ema"], state["ema_squared"], state["smoothing"]
 
                 beta1, beta2, beta3 = group["betas"]

--- a/custom_scheduler/LoraEasyCustomOptimizer/rmsprop.py
+++ b/custom_scheduler/LoraEasyCustomOptimizer/rmsprop.py
@@ -68,7 +68,7 @@ class RMSProp(Optimizer):
                     p_fp32 = p.clone().to(torch.float32)
                     ema_squared = state["ema_squared"].to(torch.float32)
                 else:
-                    grad = p.grad.data
+                    grad = grad.data
                     ema_squared = state["ema_squared"]
 
                 beta = group["betas"]

--- a/custom_scheduler/LoraEasyCustomOptimizer/rmsprop.py
+++ b/custom_scheduler/LoraEasyCustomOptimizer/rmsprop.py
@@ -62,7 +62,6 @@ class RMSProp(Optimizer):
                     state["ema_squared"] = torch.zeros_like(p.data)
 
                 # unpack
-                # unpack
                 if p.dtype in {torch.float16, torch.bfloat16}:
                     grad = grad.to(torch.float32)
                     p_fp32 = p.clone().to(torch.float32)

--- a/custom_scheduler/LoraEasyCustomOptimizer/rmsprop.py
+++ b/custom_scheduler/LoraEasyCustomOptimizer/rmsprop.py
@@ -47,7 +47,6 @@ class RMSProp(Optimizer):
         loss = closure() if closure is not None else None
         for group in self.param_groups:
             for p in group["params"]:
-                assert p.dtype == torch.bfloat16, "only bfloat 16 is supported."
                 if p.grad is None:
                     continue
                 grad = p.grad
@@ -60,12 +59,17 @@ class RMSProp(Optimizer):
                 if len(state) == 0:
                     state["step"] = 0
                     # Exponential moving average of squared gradient values
-                    state["ema_squared"] = torch.zeros_like(p.data, dtype=torch.bfloat16)
+                    state["ema_squared"] = torch.zeros_like(p.data)
 
                 # unpack
-                grad = grad.to(torch.float32)
-                p_fp32 = p.clone().to(torch.float32)
-                ema_squared = state["ema_squared"].to(torch.float32)
+                # unpack
+                if p.dtype in {torch.float16, torch.bfloat16}:
+                    grad = grad.to(torch.float32)
+                    p_fp32 = p.clone().to(torch.float32)
+                    ema_squared = state["ema_squared"].to(torch.float32)
+                else:
+                    grad = p.grad.data
+                    ema_squared = state["ema_squared"]
 
                 beta = group["betas"]
                 lr = group["lr"]
@@ -90,10 +94,16 @@ class RMSProp(Optimizer):
 
                 if weight_decay != 0:
                     # Perform stepweight decay
-                    p_fp32.data.mul_(1 - step_size * weight_decay)
+                    if p.dtype in {torch.float16, torch.bfloat16}:
+                        p_fp32.data.mul_(1 - step_size * weight_decay)
+                    else:
+                        p.data.mul_(1 - step_size * weight_decay)
 
                 # p = p - lr * grad / denom
-                p_fp32.data.addcdiv_(grad, denom, value=-step_size)
+                if p.dtype in {torch.float16, torch.bfloat16}:
+                    p_fp32.data.addcdiv_(grad, denom, value=-step_size)
+                else:
+                    p.data.addcdiv_(grad, denom, value=-step_size)
 
                 # pack
                 if p.dtype in {torch.float16, torch.bfloat16}:


### PR DESCRIPTION
All of these optimizers can work with mixed precision, unknown why they were forced to BF16 only. These changes don't break full BF16, but allow mixed precision, which based on results of training, is better.

Also adjusted default compass beta1 to 0.99 to reflect updated default in Lodestone's repo.