### PR TITLE
Update pytorch optimizer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ pyngrok
 pycloudflared
 scipy
 came-pytorch
-pytorch_optimizer==3.0.0
 lycoris-lora==3.0.1.dev10
+pytorch_optimizer==3.1.2
+wheel


### PR DESCRIPTION
- Refactor came to align with came in pytorch_optimizer 3.1.2
- Set pytorch_optimizer version to latest, 3.1.2
- Add wheel to requirements to address some Linux edge cases for building LoraEasyCustomOptimizer (unrelated to new pytorch-optimizer)

Did a run with a previous came config to validate, seems to be working fine. Some drift could be due to small degrees of nondeterminism in training or inference, and that the refactor run was done against Kohya's with stochastic rounding implemented for gradient accumulation.

![xyz_grid-0002-1436197962](https://github.com/user-attachments/assets/458b986b-5761-49ff-b60c-480cfba44ff4)