### PR TITLE
expose d on rex lr scheduler for lr_scheduler_args

### DIFF
--- a/custom_scheduler/LoraEasyCustomOptimizer/RexAnnealingWarmRestarts.py
+++ b/custom_scheduler/LoraEasyCustomOptimizer/RexAnnealingWarmRestarts.py
@@ -14,6 +14,7 @@ class RexAnnealingWarmRestarts(LRScheduler):
         min_lr: float = 1e-6,
         warmup_steps: int = 0,
         last_epoch: int = -1,
+        d: float = 0.9
     ) -> None:
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
@@ -21,7 +22,7 @@ class RexAnnealingWarmRestarts(LRScheduler):
         self.cycle_multiplier = cycle_multiplier
         self.gamma = gamma  # debating calling this decay_rate or something
         self.last_epoch = last_epoch
-        self.d = 0.9
+        self.d = d
 
         # new run
         if last_epoch == -1:


### PR DESCRIPTION
Lets people train with REX on a less aggressive curve.

As d approaches 0, the scheduler more or less becomes linear, but as it approaches 1 (default set to 0.9), it take much longer until the model starts the finer end of the fine-tune.

See this interactive graph of the REX function and mess around with d.
https://www.desmos.com/calculator/u8erssf5hh

This also enables training on lower steps with REX, as typically with 0.9, there's a very small amount of steps where the LR is small.